### PR TITLE
Add Boost.Fiber test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 project(cppgr)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(boost)
+
 add_subdirectory(tests)

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,0 +1,73 @@
+include(ExternalProject)
+include(include_once)
+include_once()
+
+include(ProcessorCount)
+ProcessorCount(NPROC)
+
+set(contrib_github_boost_git_tag boost-1.72.0)
+externalproject_add(contrib_github_boost
+    GIT_REPOSITORY    https://github.com/boostorg/boost.git
+    GIT_TAG ${contrib_github_boost_git_tag}
+    GIT_SUBMODULES tools/build
+                   tools/boost_install # from tools/build
+                   libs/config # from tools/build
+                   libs/headers # from tools/build
+                   libs/fiber
+                   libs/context # from fiber
+                   libs/smart_ptr # from fiber
+                   libs/core # from fiber
+                   libs/filesystem # from fiber
+                   libs/intrusive # from fiber
+                   libs/assert # from context
+                   libs/system # from filesystem
+                   libs/detail # from filesystem
+                   libs/predef # from filesystem
+                   libs/type_traits # from filesystem
+                   libs/iterator # from filesystem
+                   libs/io # from filesystem
+                   libs/functional # from filesystem
+                   libs/container_hash # from filesystem
+                   libs/mpl # from iterator
+                   libs/move # from intrusive
+                   libs/static_assert # from move
+                   libs/preprocessor # from mpl
+                   libs/pool # from context
+                   libs/integer # from pool
+    # Settings for faster download and to suppress warnings
+    GIT_SHALLOW 1
+    GIT_CONFIG advice.detachedHead=false submodule.fetchJobs=${NPROC} 
+    #[[
+        When CONFIGURE_COMMAND and BUILD_COMMAND are used,
+        b2 and bootstrap.sh run every time when rebuilding,
+        slow down the build.
+        Use CMakeLists.txt patching to prevent unnecessary builds
+        from running if dependencies are resolved during rebuild.
+    ]]
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/patch/boost/CMakeLists.txt <SOURCE_DIR>/CMakeLists.txt
+    UPDATE_DISCONNECTED 1
+    PREFIX contrib_github_boost-${contrib_github_boost_git_tag}
+    INSTALL_COMMAND cmake -E echo "Skipping install step."
+    BUILD_BYPRODUCTS <BINARY_DIR>/lib/libboost_context-mt-x64.a
+                     <BINARY_DIR>/lib/libboost_fiber-mt-x64.a
+)
+
+externalproject_get_property(contrib_github_boost SOURCE_DIR)
+externalproject_get_property(contrib_github_boost BINARY_DIR)
+
+include_directories(${SOURCE_DIR})
+
+add_library(boost_context STATIC IMPORTED)
+set_property(
+    TARGET boost_context
+    PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/lib/libboost_context-mt-x64.a
+)
+add_dependencies(boost_context contrib_github_boost)
+
+
+add_library(boost_fiber STATIC IMPORTED)
+set_property(
+    TARGET boost_fiber
+    PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/lib/libboost_fiber-mt-x64.a
+)
+add_dependencies(boost_fiber contrib_github_boost)

--- a/cmake/include_once.cmake
+++ b/cmake/include_once.cmake
@@ -1,0 +1,8 @@
+
+macro(include_once)
+    string(REGEX REPLACE  "\\.|\\/" "_" __underlined_parent_list_name "${CMAKE_CURRENT_LIST_FILE}")
+    if(__INCLUDE_${underlined_parent_list_name}_ONCE__)
+        return()
+    endif()
+    set(__INCLUDE_${underlined_parent_list_name}_ONCE__ TRUE)
+endmacro()

--- a/cmake/patch/boost/CMakeLists.txt
+++ b/cmake/patch/boost/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(boost)
+
+include(ProcessorCount)
+ProcessorCount(NPROC)
+
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/b2
+    COMMAND ${CMAKE_SOURCE_DIR}/bootstrap.sh --without-icu --without-libraries=python
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+add_custom_command(
+    OUTPUT ${CMAKE_SOURCE_DIR}/boost/version.hpp
+           ${CMAKE_BINARY_DIR}/lib/libboost_context-mt-x64.a
+           ${CMAKE_BINARY_DIR}/lib/libboost_fiber-mt-x64.a
+    COMMAND ${CMAKE_BINARY_DIR}/b2
+            --includedir=${CMAKE_SOURCE_DIR}
+            --reconfigure
+            --layout=tagged
+            --prefix=${CMAKE_BINARY_DIR}
+            --build-dir=${CMAKE_BINARY_DIR}
+            --stagedir=${CMAKE_BINARY_DIR}
+            -j${NPROC}
+            threading=multi
+            variant=release
+            link=static
+            cxxstd=11
+            address-model=64
+            visibility=global
+            --with-context
+            --with-fiber
+            stage
+    DEPENDS ${CMAKE_BINARY_DIR}/b2
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
+add_custom_target(build ALL
+    DEPENDS ${CMAKE_SOURCE_DIR}/boost/version.hpp
+            ${CMAKE_BINARY_DIR}/lib/libboost_context-mt-x64.a
+            ${CMAKE_BINARY_DIR}/lib/libboost_fiber-mt-x64.a
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,3 +41,13 @@ add_test(NAME test_stub
     COMMAND $<TARGET_FILE:test_stub> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_executable(test_fiber
+    test_fiber.cpp
+)
+target_link_libraries(test_fiber gtest gtest_main boost_fiber boost_context ${CMAKE_THREAD_LIBS_INIT})
+
+add_test(NAME test_fiber
+    COMMAND $<TARGET_FILE:test_fiber> --gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tests/test_fiber.cpp
+++ b/tests/test_fiber.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include <boost/fiber/all.hpp>
+
+class FiberTest : public ::testing::Test {
+protected:
+    FiberTest() {}
+    virtual ~FiberTest() {}
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_F(FiberTest, Initialization)
+{
+    auto fn = [](std::string const& str, int n){
+        for(int i=0;i<n;i++) {
+            std::cout << i << ": " << str << std::endl;
+            boost::this_fiber::yield();
+        }
+    };
+    boost::fibers::fiber f1( std::bind(fn, "abc", 5) );
+    boost::fibers::fiber f2( std::bind(fn, "xyz", 7) );
+    f1.join();
+    f2.join();
+}


### PR DESCRIPTION
#### 概要

プルリクエストの概要を簡潔にまとめること

#### 関連する Issue

#3 

#### 変更内容

[Boost公式リポジトリ](https://github.com/boostorg/boost) から必要なソースを最小限のコミットのみ clone してビルドする cmake/boost.cmake を追加した。
これにより、Boost.Fiber の利用に必要な `boost_context` と `boost_fiber`ターゲットを利用できるようになった。

また、本スクリプトが複数回、他のビルドスクリプトから include されても問題がないよう、cmake/include_once.cmake を追加し、下記のようにして include guard がかかるようにした。

```
include(include_once)
include_once()
```

また、動作確認のため、tests/test_fiber.cpp を追加した。

#### 影響範囲

なし

#### 動作要件

- [x] Visual Studio Code でプロジェクトルートを Open Folder しコマンドパレットを開いて（ Command+Shift+P）`> CMake; Configure` の実行が成功すること
- [x] コマンドパレットから `> CMake Build` の実行が成功すること
- [x] ステータスバーから `CTest の実行` を押下して ctest の実行が成功すること（1/1 件のテストが成功、と表示される）
- [x] test_fiber.cpp のテストが通ること

